### PR TITLE
implement schnorrkel and fix various idioms and linting errors

### DIFF
--- a/libdisco/apis.go
+++ b/libdisco/apis.go
@@ -1,5 +1,5 @@
-// These Utility functions implement the net.Conn interface. Most of this code
-// was either taken directly or inspired from Go's crypto/tls package.
+// Package libdisco these utility functions implement the net.Conn interface.
+// Most of this code was either taken directly or inspired from Go's crypto/tls package.
 package libdisco
 
 import (
@@ -32,7 +32,7 @@ func Client(conn net.Conn, config *Config) *Conn {
 	return &Conn{conn: conn, config: config, isClient: true}
 }
 
-// A listener implements a network listener (net.Listener) for Disco connections.
+// Listener implements a network listener (net.Listener) for Disco connections.
 type Listener struct {
 	net.Listener
 	config *Config
@@ -48,7 +48,7 @@ func (l *Listener) Accept() (net.Conn, error) {
 	return Server(c, l.config), nil
 }
 
-// Accept waits for and returns the next incoming Disco connection.
+// AcceptDisco waits for and returns the next incoming Disco connection.
 // The returned connection is of type *Conn.
 func (l *Listener) AcceptDisco() (*Conn, error) {
 	c, err := l.Listener.Accept()
@@ -123,21 +123,21 @@ var errNoProof = errors.New("Disco: no public key proof set in Config")
 
 func checkRequirements(isClient bool, config *Config) (err error) {
 	ht := config.HandshakePattern
-	if ht == Noise_NX || ht == Noise_KX || ht == Noise_XX || ht == Noise_IX {
+	if ht == NoiseNX || ht == NoiseKX || ht == NoiseXX || ht == NoiseIX {
 		if isClient && config.PublicKeyVerifier == nil {
 			return errNoPubkeyVerifier
 		} else if !isClient && config.StaticPublicKeyProof == nil {
 			return errNoProof
 		}
 	}
-	if ht == Noise_XN || ht == Noise_XK || ht == Noise_XX || ht == Noise_X || ht == Noise_IN || ht == Noise_IK || ht == Noise_IX {
+	if ht == NoiseXN || ht == NoiseXK || ht == NoiseXX || ht == NoiseX || ht == NoiseIN || ht == NoiseIK || ht == NoiseIX {
 		if isClient && config.StaticPublicKeyProof == nil {
 			return errNoProof
 		} else if !isClient && config.PublicKeyVerifier == nil {
 			return errNoPubkeyVerifier
 		}
 	}
-	if ht == Noise_NNpsk2 && len(config.PreSharedKey) != 32 {
+	if ht == NoiseNNpsk2 && len(config.PreSharedKey) != 32 {
 		return errors.New("noise: a 32-byte pre-shared key needs to be passed as noise.Config")
 	}
 	return nil

--- a/libdisco/apis.go
+++ b/libdisco/apis.go
@@ -1,4 +1,4 @@
-// Package libdisco these utility functions implement the net.Conn interface.
+// Package libdisco this file implements a net.Conn interface over Disco.
 // Most of this code was either taken directly or inspired from Go's crypto/tls package.
 package libdisco
 

--- a/libdisco/apis.go
+++ b/libdisco/apis.go
@@ -1,7 +1,7 @@
-// Package libdisco this file implements a net.Conn interface over Disco.
-// Most of this code was either taken directly or inspired from Go's crypto/tls package.
 package libdisco
 
+// This file implements a net.Conn interface over Disco.
+// Most of this code was either taken directly or inspired from Go's crypto/tls package.
 import (
 	"crypto"
 	"crypto/rand"

--- a/libdisco/asymmetric.go
+++ b/libdisco/asymmetric.go
@@ -4,18 +4,21 @@ import (
 	"bytes"
 	"crypto/rand"
 	"encoding/hex"
-	"fmt"
 
-	ristretto "github.com/bwesterb/go-ristretto"
+	ristretto "github.com/gtank/ristretto255"
 	"golang.org/x/crypto/curve25519"
 )
 
 //
 // The following code defines the X25519, chacha20poly1305, SHA-256 suite.
 //
+// The following code implements the Schnorrkel variant of Schnorr signatures
+// over ristretto255.
+// This implementation was picked from https://github.com/w3f/schnorrkel
 
 const (
-	dhLen = 32 // A constant specifying the size in bytes of public keys and DH outputs. For security reasons, dhLen must be 32 or greater.
+	dhLen  = 32 // A constant specifying the size in bytes of public keys and DH outputs. For security reasons, dhLen must be 32 or greater.
+	skSize = 32 // a secret key is encoded as a 32 byte array.
 )
 
 // 4.1. DH functions
@@ -24,7 +27,7 @@ const (
 
 // KeyPair contains a private and a public part, both of 32-byte.
 // It can be generated via the GenerateKeyPair() function.
-// The public part can also be extracted via the ExportPublicKey() function.
+// The public part can also be extracted via the String() function.
 type KeyPair struct {
 	PrivateKey [32]byte // must stay a [32]byte because of Serialize()
 	PublicKey  [32]byte // must stay a [32]byte because of Serialize()
@@ -47,8 +50,8 @@ func GenerateKeypair(privateKey *[32]byte) *KeyPair {
 	return &keyPair
 }
 
-// ExportPublicKey returns the public part in hex format of a static key pair.
-func (kp KeyPair) ExportPublicKey() string {
+// String returns the public part in hex format of a static key pair.
+func (kp KeyPair) String() string {
 	return hex.EncodeToString(kp.PublicKey[:])
 }
 
@@ -59,85 +62,173 @@ func dh(keyPair KeyPair, publicKey [32]byte) (shared [32]byte) {
 	return
 }
 
-// uses deterministic Schnorr with strobe
-type SigningKeyPair struct {
+// SigningKeypair uses deterministic Schnorr with strobe
+type SigningKeypair struct {
 	SecretKey ristretto.Scalar
-	PublicKey ristretto.Point
+	PublicKey ristretto.Element
 }
 
-//
-func GenerateSigningKeyPair() SigningKeyPair {
-	// Generate an El'Gamal keypair
-	var secretKey ristretto.Scalar
-	var publicKey ristretto.Point
-
-	secretKey.Rand()                     // generate a new secret key
-	publicKey.ScalarMultBase(&secretKey) // compute public key
-
-	return SigningKeyPair{secretKey, publicKey}
+// Signature represents a schnorrkel signature
+type Signature struct {
+	R ristretto.Element
+	S ristretto.Scalar
 }
 
-func (kp SigningKeyPair) ExportPublicKey() string {
-	return hex.EncodeToString(kp.SecretKey.Bytes()) + hex.EncodeToString(kp.PublicKey.Bytes())
-}
-
-//
-func (kp SigningKeyPair) Sign(message []byte) []byte {
-	// 1. deterministic ephemeral k; r=g^k
-	var kBytes [32]byte
-	copy(kBytes[:], Hash(append(kp.SecretKey.Bytes(), message...), 32))
-	var k ristretto.Scalar
-	k.SetBytes(&kBytes)
-	var r ristretto.Point
-	r.ScalarMultBase(&k)
-
-	// 2. e = H(r || M)
-	e := Hash(append(r.Bytes(), message...), 32)
-	var e32 [32]byte
-	copy(e32[:], e)
-	// 3. s = k - xe
-	var xe ristretto.Scalar
-	var eScal ristretto.Scalar
-	eScal.SetBytes(&e32)
-	xe.Mul(&kp.SecretKey, &eScal)
-	var s ristretto.Scalar
-	s.Sub(&k, &xe)
-
-	// 4. return (s, e)
-	return append(s.Bytes(), e...)
-}
-
-//
-func (kp SigningKeyPair) Verify(message, signature []byte) error {
-	// 0. (s, e) = sig
-	if len(signature) != 64 {
-		return fmt.Errorf("disco: signature length incorrect")
+// Decode a schnorrkel signature from a bytearray.
+// ref: https://github.com/w3f/schnorrkel/blob/master/src/sign.rs#L100
+func (s *Signature) Decode(sigBytes [64]byte) error {
+	err := s.R.Decode(sigBytes[:32])
+	if err != nil {
+		return err
 	}
-	var s, e [32]byte
-	copy(s[:], signature[:32])
-	copy(e[:], signature[32:])
-
-	// 1. rv = g^s y^e
-	var gs ristretto.Point
-	var sScal ristretto.Scalar
-	sScal.SetBytes(&s)
-	gs.ScalarMultBase(&sScal)
-	var ye ristretto.Point
-	var eScal ristretto.Scalar
-	eScal.SetBytes(&e)
-	ye.PublicScalarMult(&kp.PublicKey, &eScal)
-
-	var rv ristretto.Point
-	rv.Add(&gs, &ye)
-
-	// 2. ev = H(rv || M)
-	ev := Hash(append(rv.Bytes(), message...), 32)
-
-	// 3. ev = e ?
-	if !bytes.Equal(ev, e[:]) {
-		return fmt.Errorf("disco: signature is invalid")
+	sigBytes[63] &= 127
+	err = s.S.Decode(sigBytes[32:])
+	if err != nil {
+		return err
 	}
-
-	//
 	return nil
+}
+
+// Encode a signature as a bytearray.
+// see: https://github.com/w3f/schnorrkel/blob/master/src/sign.rs#L77
+func (s *Signature) Encode() [64]byte {
+	var sigBytes [64]byte
+
+	rBytes := s.R.Encode(nil)
+	copy(sigBytes[:32], rBytes)
+
+	sBytes := s.S.Encode(nil)
+	copy(sigBytes[32:], sBytes)
+
+	sigBytes[63] |= 128
+
+	return sigBytes
+}
+
+// GenerateSigningKeypair for schnorr signatures.
+func GenerateSigningKeypair() (SigningKeypair, error) {
+
+	var sigpair SigningKeypair
+	// Generate a schnorr keypair
+	var publicKey ristretto.Element
+
+	secretKey, err := newRandomScalar()
+	if err != nil {
+		return sigpair, err
+	}
+	sigpair.PublicKey = *publicKey.ScalarBaseMult(&secretKey)
+	sigpair.SecretKey = secretKey
+
+	return sigpair, nil
+}
+
+// String returns a hexstring encoding of the signing keypair.
+func (kp SigningKeypair) String() string {
+	return hex.EncodeToString(kp.SecretKey.Encode(nil)) + hex.EncodeToString(kp.PublicKey.Encode(nil))
+}
+
+// Sign a message using a deterministic nonce
+func (kp SigningKeypair) Sign(message []byte) Signature {
+
+	// choose a deterministic nonce
+
+	var kBytes [64]byte
+	// preallocate and avoid append allocations
+	var buf = make([]byte, 0, skSize+len(message))
+	buf = append(buf, kp.SecretKey.Encode(nil)...)
+	buf = append(buf, message...)
+	// buf ownership passed to reusable buffer
+	var reusableBuffer = bytes.NewBuffer(buf)
+	// the output should be 64 byte per ristretto255 rfc
+	// ref : https://tools.ietf.org/html/draft-hdevalence-cfrg-ristretto-00
+	copy(kBytes[:], Hash(reusableBuffer.Bytes(), 64))
+	// cleanup
+	reusableBuffer.Reset()
+	var k ristretto.Scalar
+	var R ristretto.Element
+
+	k.FromUniformBytes(kBytes[:])
+	R.ScalarBaseMult(&k)
+
+	var e ristretto.Scalar
+	var x ristretto.Scalar
+	var s ristretto.Scalar
+
+	// e = H(R||message)
+	reusableBuffer.Write(R.Encode(nil))
+	reusableBuffer.Write(message)
+
+	h := Hash(reusableBuffer.Bytes(), 64)
+	e.FromUniformBytes(h)
+
+	reusableBuffer.Reset()
+	// x = sk*e
+	x.Multiply(&kp.SecretKey, &e)
+	// s = k + x
+	s.Add(&k, &x)
+
+	sig := Signature{R, s}
+
+	return sig
+
+}
+
+// Verify a signature
+func (kp SigningKeypair) Verify(message []byte, signature Signature) (bool, error) {
+
+	// Verifying a signature of the form R,s
+	// Decoding the signature
+
+	var R ristretto.Element
+	var s ristretto.Scalar
+
+	R = signature.R
+	s = signature.S
+
+	ev := Hash(append(R.Encode(nil), message...), 64)
+
+	var k ristretto.Scalar
+	k.FromUniformBytes(ev)
+
+	var Rp ristretto.Element
+	Rp.ScalarBaseMult(&s)
+
+	var ky ristretto.Element
+	ky.ScalarMult(&k, &kp.PublicKey)
+
+	Rp.Subtract(&Rp, &ky)
+
+	return Rp.Equal(&R) == 1, nil
+
+}
+
+// newRandomScalar generates a random ristretto scalar using crypto/rand.
+func newRandomScalar() (ristretto.Scalar, error) {
+
+	var buf [64]byte
+	var s ristretto.Scalar
+
+	n, err := rand.Read(buf[:])
+
+	if n != 64 || err != nil {
+		return s, err
+	}
+
+	s.FromUniformBytes(buf[:])
+	return s, nil
+}
+
+// newRandomElement generates a random ristretto point using crypto/rand.
+func newRandomElement() (ristretto.Element, error) {
+
+	var buf [64]byte
+	var P ristretto.Element
+
+	n, err := rand.Read(buf[:])
+
+	if n != 64 || err != nil {
+		return P, err
+	}
+	P.FromUniformBytes(buf[:])
+	return P, nil
 }

--- a/libdisco/asymmetric_test.go
+++ b/libdisco/asymmetric_test.go
@@ -14,7 +14,8 @@ func TestSignVerify(t *testing.T) {
 	}
 	sig := kp.Sign(input)
 
-	if ok, err := kp.Verify(input, sig); !ok || err != nil {
+	err = kp.Verify(input, sig)
+	if err != nil {
 		t.Fatal("failed to verify signature with error : ", err)
 	}
 }
@@ -36,39 +37,15 @@ func TestDeterministicSignatures(t *testing.T) {
 	}
 }
 
-func BenchmarkSign(b *testing.B) {
-	input := []byte("benchmark how fast do I get signed")
-
-	for n := 0; n < b.N; n++ {
-		kp, err := GenerateSigningKeypair()
-
-		if err != nil {
-			b.Fatal("failed to generate signing keypair")
-		}
-		sig := kp.Sign(input)
-
-		if ok, err := kp.Verify(input, sig); !ok || err != nil {
-			b.Fatal("failed to verify signature with error : ", err)
-		}
-
-	}
-}
-
-func BenchmarkDeterministicSign(b *testing.B) {
+func BenchmarkSignVerify(b *testing.B) {
 	kp, err := GenerateSigningKeypair()
 	if err != nil {
 		b.Fatal("failed to generate a signing keypair")
 	}
 	input := []byte("benchmark how fast do I get signed and it stays consistent")
-	signature := kp.Sign(input)
-	sigBytes := signature.Encode()
+
 	for n := 0; n < b.N; n++ {
-		sigN := kp.Sign(input)
-
-		sigNBytes := sigN.Encode()
-
-		if !bytes.Equal(sigBytes[:], sigNBytes[:]) {
-			b.Fatal("failed to generate deterministic signatures")
-		}
+		sig := kp.Sign(input)
+		kp.Verify(input, sig)
 	}
 }

--- a/libdisco/asymmetric_test.go
+++ b/libdisco/asymmetric_test.go
@@ -7,21 +7,68 @@ import (
 
 func TestSignVerify(t *testing.T) {
 	input := []byte("hi, how are you?")
-	kp := GenerateSigningKeyPair()
+	kp, err := GenerateSigningKeypair()
+
+	if err != nil {
+		t.Fatal("failed to generate a signing keypair")
+	}
 	sig := kp.Sign(input)
 
-	if kp.Verify(input, sig) != nil {
-		t.Fatal("Schnorr doesn't work")
+	if ok, err := kp.Verify(input, sig); !ok || err != nil {
+		t.Fatal("failed to verify signature with error : ", err)
 	}
 }
 
 func TestDeterministicSignatures(t *testing.T) {
-	kp := GenerateSigningKeyPair()
+	kp, err := GenerateSigningKeypair()
+	if err != nil {
+		t.Fatal("failed to generate a signing keypair")
+	}
 	input := []byte("hi, how are you?")
 	sig1 := kp.Sign(input)
 	sig2 := kp.Sign(input)
 
-	if !bytes.Equal(sig1, sig2) {
-		t.Fatal("Signatures are not deterministic doesn't work")
+	sig1Bytes := sig1.Encode()
+	sig2Bytes := sig2.Encode()
+
+	if !bytes.Equal(sig1Bytes[:], sig2Bytes[:]) {
+		t.Fatal("signatures are not deterministic doesn't work")
+	}
+}
+
+func BenchmarkSign(b *testing.B) {
+	input := []byte("benchmark how fast do I get signed")
+
+	for n := 0; n < b.N; n++ {
+		kp, err := GenerateSigningKeypair()
+
+		if err != nil {
+			b.Fatal("failed to generate signing keypair")
+		}
+		sig := kp.Sign(input)
+
+		if ok, err := kp.Verify(input, sig); !ok || err != nil {
+			b.Fatal("failed to verify signature with error : ", err)
+		}
+
+	}
+}
+
+func BenchmarkDeterministicSign(b *testing.B) {
+	kp, err := GenerateSigningKeypair()
+	if err != nil {
+		b.Fatal("failed to generate a signing keypair")
+	}
+	input := []byte("benchmark how fast do I get signed and it stays consistent")
+	signature := kp.Sign(input)
+	sigBytes := signature.Encode()
+	for n := 0; n < b.N; n++ {
+		sigN := kp.Sign(input)
+
+		sigNBytes := sigN.Encode()
+
+		if !bytes.Equal(sigBytes[:], sigNBytes[:]) {
+			b.Fatal("failed to generate deterministic signatures")
+		}
 	}
 }

--- a/libdisco/conn.go
+++ b/libdisco/conn.go
@@ -47,14 +47,18 @@ func (c *Conn) LocalAddr() net.Addr {
 	return c.conn.LocalAddr()
 }
 
+// Addr abstract an address
 type Addr struct {
 	network string
 	address string
 }
 
+// Network returns addr network
 func (a Addr) Network() string {
 	return a.network
 }
+
+// String implements stringer interface
 func (a Addr) String() string {
 	return a.address
 }
@@ -94,7 +98,7 @@ func (c *Conn) SetWriteDeadline(t time.Time) error {
 func (c *Conn) Write(b []byte) (int, error) {
 
 	//
-	if hp := c.config.HandshakePattern; !c.isClient && (hp == Noise_N || hp == Noise_K || hp == Noise_X) {
+	if hp := c.config.HandshakePattern; !c.isClient && (hp == NoiseN || hp == NoiseK || hp == NoiseX) {
 		panic("disco: a server should not write on one-way patterns")
 	}
 
@@ -160,7 +164,7 @@ func (c *Conn) Read(b []byte) (n int, err error) {
 	}
 
 	// If this is a one-way pattern, do some checks
-	if hp := c.config.HandshakePattern; c.isClient && (hp == Noise_N || hp == Noise_K || hp == Noise_X) {
+	if hp := c.config.HandshakePattern; c.isClient && (hp == NoiseN || hp == NoiseK || hp == NoiseX) {
 		panic("disco: a client should not read on one-way patterns")
 	}
 

--- a/libdisco/conn.go
+++ b/libdisco/conn.go
@@ -47,13 +47,13 @@ func (c *Conn) LocalAddr() net.Addr {
 	return c.conn.LocalAddr()
 }
 
-// Addr abstract an address
+// Addr represents a newtork address.
 type Addr struct {
 	network string
 	address string
 }
 
-// Network returns addr network
+// Network returns the network.
 func (a Addr) Network() string {
 	return a.network
 }

--- a/libdisco/conn_test.go
+++ b/libdisco/conn_test.go
@@ -233,7 +233,7 @@ func TestRemotePublicKey(t *testing.T) {
 	}
 
 	// need to send a message for the handshake to start
-	_, err = clientSocket.Write([]byte(clientConfig.KeyPair.String()))
+	_, err = clientSocket.Write([]byte(clientConfig.KeyPair.ExportPublicKey()))
 	if err != nil {
 		t.Fatal("client can't write on socket")
 	}

--- a/libdisco/conn_test.go
+++ b/libdisco/conn_test.go
@@ -16,13 +16,13 @@ func TestSeveralWriteRead(t *testing.T) {
 	// init
 	clientConfig := Config{
 		KeyPair:              GenerateKeypair(nil),
-		HandshakePattern:     Noise_XX,
+		HandshakePattern:     NoiseXX,
 		StaticPublicKeyProof: []byte{},
 		PublicKeyVerifier:    verifier,
 	}
 	serverConfig := Config{
 		KeyPair:              GenerateKeypair(nil),
-		HandshakePattern:     Noise_XX,
+		HandshakePattern:     NoiseXX,
 		StaticPublicKeyProof: []byte{},
 		PublicKeyVerifier:    verifier,
 	}
@@ -83,14 +83,14 @@ func TestHalfDuplex(t *testing.T) {
 	// init
 	clientConfig := Config{
 		KeyPair:              GenerateKeypair(nil),
-		HandshakePattern:     Noise_XX,
+		HandshakePattern:     NoiseXX,
 		StaticPublicKeyProof: []byte{},
 		PublicKeyVerifier:    verifier,
 		HalfDuplex:           true,
 	}
 	serverConfig := Config{
 		KeyPair:              GenerateKeypair(nil),
-		HandshakePattern:     Noise_XX,
+		HandshakePattern:     NoiseXX,
 		StaticPublicKeyProof: []byte{},
 		PublicKeyVerifier:    verifier,
 		HalfDuplex:           true,
@@ -183,13 +183,13 @@ func TestRemotePublicKey(t *testing.T) {
 	// init
 	clientConfig := Config{
 		KeyPair:              GenerateKeypair(nil),
-		HandshakePattern:     Noise_XX,
+		HandshakePattern:     NoiseXX,
 		StaticPublicKeyProof: []byte{},
 		PublicKeyVerifier:    verifier,
 	}
 	serverConfig := Config{
 		KeyPair:                        GenerateKeypair(nil),
-		HandshakePattern:               Noise_XX,
+		HandshakePattern:               NoiseXX,
 		StaticPublicKeyProof:           []byte{},
 		PublicKeyVerifier:              verifier,
 		RemoteAddrContainsRemotePubkey: true,
@@ -233,7 +233,7 @@ func TestRemotePublicKey(t *testing.T) {
 	}
 
 	// need to send a message for the handshake to start
-	_, err = clientSocket.Write([]byte(clientConfig.KeyPair.ExportPublicKey()))
+	_, err = clientSocket.Write([]byte(clientConfig.KeyPair.String()))
 	if err != nil {
 		t.Fatal("client can't write on socket")
 	}

--- a/libdisco/disco_test.go
+++ b/libdisco/disco_test.go
@@ -49,7 +49,7 @@ func throughput(b *testing.B, totalBytes int64) {
 				panic(fmt.Errorf("accept: %v", err))
 			}
 			serverConfig := &Config{
-				HandshakePattern: Noise_NK,
+				HandshakePattern: NoiseNK,
 				KeyPair:          serverKeyPair,
 			}
 			srv := Server(sconn, serverConfig)
@@ -64,7 +64,7 @@ func throughput(b *testing.B, totalBytes int64) {
 
 	b.SetBytes(totalBytes)
 	clientConfig := &Config{
-		HandshakePattern: Noise_NK,
+		HandshakePattern: NoiseNK,
 		RemoteKey:        serverKeyPair.PublicKey[:],
 	}
 
@@ -143,7 +143,7 @@ func latency(b *testing.B, bps int) {
 				panic(fmt.Errorf("accept: %v", err))
 			}
 			serverConfig := &Config{
-				HandshakePattern: Noise_NK,
+				HandshakePattern: NoiseNK,
 				KeyPair:          serverKeyPair,
 			}
 			srv := Server(&slowConn{sconn, bps}, serverConfig)
@@ -155,7 +155,7 @@ func latency(b *testing.B, bps int) {
 	}()
 
 	clientConfig := &Config{
-		HandshakePattern: Noise_NK,
+		HandshakePattern: NoiseNK,
 		RemoteKey:        serverKeyPair.PublicKey[:],
 	}
 
@@ -197,7 +197,7 @@ func TestSerialize(t *testing.T) {
 	// init
 	s := GenerateKeypair(nil)
 	rs := GenerateKeypair(nil)
-	hs := Initialize(Noise_IK, true, nil, s, nil, rs, nil)
+	hs := Initialize(NoiseIK, true, nil, s, nil, rs, nil)
 	// write first message
 	var msg []byte
 	hs.WriteMessage(nil, &msg)
@@ -207,18 +207,18 @@ func TestSerialize(t *testing.T) {
 	hs2 := RecoverState(serialized, nil, s)
 
 	// let's write a message to parse
-	hs_bob := Initialize(Noise_IK, false, nil, rs, nil, s, nil)
+	hsBob := Initialize(NoiseIK, false, nil, rs, nil, s, nil)
 	var msg2 []byte
-	hs_bob.ReadMessage(msg, &msg2)
+	hsBob.ReadMessage(msg, &msg2)
 	msg2 = msg2[:0]
-	hs_bob.WriteMessage([]byte("hello"), &msg2)
+	hsBob.WriteMessage([]byte("hello"), &msg2)
 
 	// let's parse it
-	var msg_rcv1, msg_rcv2 []byte
-	c1, c2, _ := hs.ReadMessage(msg2, &msg_rcv1)
-	t1, t2, _ := hs2.ReadMessage(msg2, &msg_rcv2)
+	var msgRcv1, msgRcv2 []byte
+	c1, c2, _ := hs.ReadMessage(msg2, &msgRcv1)
+	t1, t2, _ := hs2.ReadMessage(msg2, &msgRcv2)
 
-	if !bytes.Equal(msg_rcv1, msg_rcv2) {
+	if !bytes.Equal(msgRcv1, msgRcv2) {
 		t.Fatal("received message not as expected")
 	}
 

--- a/libdisco/examples/Noise_K/client/client.go
+++ b/libdisco/examples/Noise_K/client/client.go
@@ -16,7 +16,7 @@ func main() {
 
 	// configure the Disco connection
 	clientConfig := libdisco.Config{
-		HandshakePattern: libdisco.Noise_K,
+		HandshakePattern: libdisco.NoiseK,
 		KeyPair:          clientKeyPair,
 	}
 

--- a/libdisco/examples/Noise_K/server/server.go
+++ b/libdisco/examples/Noise_K/server/server.go
@@ -17,7 +17,7 @@ func main() {
 
 	// configuring the Disco connection
 	serverConfig := libdisco.Config{
-		HandshakePattern: libdisco.Noise_K,
+		HandshakePattern: libdisco.NoiseK,
 		KeyPair:          serverKeyPair,
 	}
 

--- a/libdisco/examples/Noise_KK/client/client.go
+++ b/libdisco/examples/Noise_KK/client/client.go
@@ -18,7 +18,7 @@ func main() {
 	// in which the client knows the static public key of the server
 	// and the server knows the static public key of the client
 	clientConfig := libdisco.Config{
-		HandshakePattern: libdisco.Noise_KK,
+		HandshakePattern: libdisco.NoiseKK,
 		KeyPair:          clientKeyPair,
 	}
 

--- a/libdisco/examples/Noise_KK/server/server.go
+++ b/libdisco/examples/Noise_KK/server/server.go
@@ -17,7 +17,7 @@ func main() {
 
 	// configuring the Disco connection
 	serverConfig := libdisco.Config{
-		HandshakePattern: libdisco.Noise_KK,
+		HandshakePattern: libdisco.NoiseKK,
 		KeyPair:          serverKeyPair,
 	}
 

--- a/libdisco/examples/Noise_N/client/client.go
+++ b/libdisco/examples/Noise_N/client/client.go
@@ -17,7 +17,7 @@ func main() {
 	// configure the Disco connection with Noise_N
 	// meaning the client knows the server's static public key (retrieved from the CLI)
 	clientConfig := libdisco.Config{
-		HandshakePattern: libdisco.Noise_N,
+		HandshakePattern: libdisco.NoiseN,
 		RemoteKey:        serverKey,
 	}
 	// Dial the port 6666 of localhost

--- a/libdisco/examples/Noise_N/server/server.go
+++ b/libdisco/examples/Noise_N/server/server.go
@@ -14,7 +14,7 @@ func main() {
 	// configuring the Disco connection with a Noise_N handshake
 	// in which the client already knows the server's static public key
 	serverConfig := libdisco.Config{
-		HandshakePattern: libdisco.Noise_N,
+		HandshakePattern: libdisco.NoiseN,
 		KeyPair:          serverKeyPair,
 	}
 	// listen on port 6666

--- a/libdisco/examples/Noise_NK/client/client.go
+++ b/libdisco/examples/Noise_NK/client/client.go
@@ -16,7 +16,7 @@ func main() {
 	// configure the Disco connection with Noise_NK
 	// meaning the client knows the key (retrieved from the CLI)
 	clientConfig := libdisco.Config{
-		HandshakePattern: libdisco.Noise_NK,
+		HandshakePattern: libdisco.NoiseNK,
 		RemoteKey:        serverPublicKey,
 	}
 	// Dial the port 6666 of localhost

--- a/libdisco/examples/Noise_NK/server/server.go
+++ b/libdisco/examples/Noise_NK/server/server.go
@@ -14,7 +14,7 @@ func main() {
 	// configuring the Disco connection with a Noise_NK handshake
 	// in which the client already knows the server's public key
 	serverConfig := libdisco.Config{
-		HandshakePattern: libdisco.Noise_NK,
+		HandshakePattern: libdisco.NoiseNK,
 		KeyPair:          serverKeyPair,
 	}
 	// listen on port 6666

--- a/libdisco/examples/Noise_NNpsk2/client/client.go
+++ b/libdisco/examples/Noise_NNpsk2/client/client.go
@@ -21,7 +21,7 @@ func main() {
 
 	// configure the Disco connection
 	clientConfig := libdisco.Config{
-		HandshakePattern: libdisco.Noise_NNpsk2,
+		HandshakePattern: libdisco.NoiseNNpsk2,
 		PreSharedKey:     sharedSecret,
 	}
 

--- a/libdisco/examples/Noise_NNpsk2/server/server.go
+++ b/libdisco/examples/Noise_NNpsk2/server/server.go
@@ -21,7 +21,7 @@ func main() {
 
 	// configuring the Disco connection
 	serverConfig := libdisco.Config{
-		HandshakePattern: libdisco.Noise_NNpsk2,
+		HandshakePattern: libdisco.NoiseNNpsk2,
 		PreSharedKey:     sharedSecret,
 	}
 

--- a/libdisco/examples/Noise_NX/client/client.go
+++ b/libdisco/examples/Noise_NX/client/client.go
@@ -27,7 +27,7 @@ func main() {
 
 	// configure the Disco connection
 	clientConfig := libdisco.Config{
-		HandshakePattern:  libdisco.Noise_NX,
+		HandshakePattern:  libdisco.NoiseNX,
 		PublicKeyVerifier: verifier,
 	}
 

--- a/libdisco/examples/Noise_NX/server/server.go
+++ b/libdisco/examples/Noise_NX/server/server.go
@@ -51,7 +51,7 @@ func main() {
 		// configure the Disco connection
 		serverConfig := libdisco.Config{
 			KeyPair:              serverKeyPair,
-			HandshakePattern:     libdisco.Noise_NX,
+			HandshakePattern:     libdisco.NoiseNX,
 			StaticPublicKeyProof: proof,
 		}
 

--- a/libdisco/examples/Noise_X/client/client.go
+++ b/libdisco/examples/Noise_X/client/client.go
@@ -59,7 +59,7 @@ func main() {
 		clientConfig := libdisco.Config{
 			KeyPair:              clientKeyPair,
 			RemoteKey:            serverPublicKey,
-			HandshakePattern:     libdisco.Noise_X,
+			HandshakePattern:     libdisco.NoiseX,
 			StaticPublicKeyProof: proof,
 		}
 

--- a/libdisco/examples/Noise_X/server/server.go
+++ b/libdisco/examples/Noise_X/server/server.go
@@ -33,7 +33,7 @@ func main() {
 	// configuring the Disco connection
 	// in which the client already knows the server's public key
 	serverConfig := libdisco.Config{
-		HandshakePattern:  libdisco.Noise_X,
+		HandshakePattern:  libdisco.NoiseX,
 		KeyPair:           serverKeyPair,
 		PublicKeyVerifier: verifier,
 	}

--- a/libdisco/examples/Noise_XX/client/client.go
+++ b/libdisco/examples/Noise_XX/client/client.go
@@ -61,7 +61,7 @@ func main() {
 		// configure the Disco connection with Noise_XX
 		clientConfig := libdisco.Config{
 			KeyPair:              clientKeyPair,
-			HandshakePattern:     libdisco.Noise_XX,
+			HandshakePattern:     libdisco.NoiseXX,
 			PublicKeyVerifier:    verifier,
 			StaticPublicKeyProof: proof,
 		}

--- a/libdisco/examples/Noise_XX/server/server.go
+++ b/libdisco/examples/Noise_XX/server/server.go
@@ -61,7 +61,7 @@ func main() {
 		// configure the Disco connection with Noise_XX
 		serverConfig := libdisco.Config{
 			KeyPair:              serverKeyPair,
-			HandshakePattern:     libdisco.Noise_XX,
+			HandshakePattern:     libdisco.NoiseXX,
 			PublicKeyVerifier:    verifier,
 			StaticPublicKeyProof: proof,
 		}

--- a/libdisco/patterns.go
+++ b/libdisco/patterns.go
@@ -7,61 +7,71 @@ package libdisco
 type noiseHandshakeType int8
 
 const (
-	// Noise_N is a one-way pattern where a client can send
+	// NoiseUnknown is for specifying an unknown pattern
+	NoiseUnknown noiseHandshakeType = iota
+	// NoiseN is a one-way pattern where a client can send
 	// data to a server with a known static key. The server
 	// can only receive data and cannot reply back.
-	Noise_N noiseHandshakeType = iota
+	NoiseN
 
-	// Noise_K is a one-way pattern where a client can send
+	// NoiseK is a one-way pattern where a client can send
 	// data to a server with a known static key. The server
 	// can only receive data and cannot reply back. The server
 	// authenticates the client via a known key.
-	Noise_K
+	NoiseK
 
-	// Noise_X is a one-way pattern where a client can send
+	// NoiseX is a one-way pattern where a client can send
 	// data to a server with a known static key. The server
 	// can only receive data and cannot reply back. The server
 	// authenticates the client via a key transmitted as part
 	// of the handshake.
-	Noise_X
+	NoiseX
 
-	// Noise_KK is a pattern where both the client static key and the
+	// NoiseKK is a pattern where both the client static key and the
 	// server static key are known.
-	Noise_KK
+	NoiseKK
 
-	// Noise_NX is a "HTTPS"-like pattern where the client is
+	// NoiseNX is a "HTTPS"-like pattern where the client is
 	// not authenticated, and the static public key of the server
 	// is transmitted during the handshake. It is the responsability of the client to validate the received key properly.
-	Noise_NX
+	NoiseNX
 
-	// Noise_NK is a "Public Key Pinning"-like pattern where the client
+	// NoiseNK is a "Public Key Pinning"-like pattern where the client
 	// is not authenticated, and the static public key of the server
 	// is already known.
-	Noise_NK
+	NoiseNK
 
-	// Noise_XX is a pattern where both static keys are transmitted.
+	// NoiseXX is a pattern where both static keys are transmitted.
 	// It is the responsability of the server and of the client to
 	// validate the received keys properly.
-	Noise_XX
+	NoiseXX
 
-	// Not documented
-	Noise_KX
-	Noise_XK
-	Noise_IK
-	Noise_IX
-	Noise_NNpsk2
+	// NoiseKX Not documented
+	NoiseKX
+	// NoiseXK Not documented
+	NoiseXK
+	// NoiseIK Not documented
+	NoiseIK
+	// NoiseIX Not documented
+	NoiseIX
+	// NoiseNNpsk2 Not documented
+	NoiseNNpsk2
 
-	// Not implemented
-	Noise_NN
-	Noise_KN
-	Noise_XN
-	Noise_IN
+	// NoiseNN Not implemented
+	NoiseNN
+	// NoiseKN Not implemented
+	NoiseKN
+	// NoiseXN Not implemented
+	NoiseXN
+	// NoiseIN Not implemented
+	NoiseIN
 )
 
 type token uint8
 
 const (
-	token_e token = iota
+	tokenUnknown token = iota
+	token_e
 	token_s
 	token_es
 	token_se
@@ -83,7 +93,7 @@ var patterns = map[noiseHandshakeType]handshakePattern{
 
 	// 7.2. One-way patterns
 
-	Noise_N: handshakePattern{
+	NoiseN: handshakePattern{
 		name: "N",
 		preMessagePatterns: []messagePattern{
 			messagePattern{},        // →
@@ -101,7 +111,7 @@ var patterns = map[noiseHandshakeType]handshakePattern{
 		  ...
 		  -> e, es, ss
 	*/
-	Noise_K: handshakePattern{
+	NoiseK: handshakePattern{
 		name: "K",
 		preMessagePatterns: []messagePattern{
 			messagePattern{token_s}, // →
@@ -117,7 +127,7 @@ var patterns = map[noiseHandshakeType]handshakePattern{
 		 ...
 		 -> e, es, s, ss
 	*/
-	Noise_X: handshakePattern{
+	NoiseX: handshakePattern{
 		name: "X",
 		preMessagePatterns: []messagePattern{
 			messagePattern{},        // →
@@ -130,7 +140,7 @@ var patterns = map[noiseHandshakeType]handshakePattern{
 	//
 	// 7.3. Interactive patterns
 	//
-	Noise_KK: handshakePattern{
+	NoiseKK: handshakePattern{
 		name: "KK",
 		preMessagePatterns: []messagePattern{
 			messagePattern{token_s}, // →
@@ -142,7 +152,7 @@ var patterns = map[noiseHandshakeType]handshakePattern{
 		},
 	},
 
-	Noise_NX: handshakePattern{
+	NoiseNX: handshakePattern{
 		name: "NX",
 		preMessagePatterns: []messagePattern{
 			messagePattern{}, // →
@@ -154,7 +164,7 @@ var patterns = map[noiseHandshakeType]handshakePattern{
 		},
 	},
 
-	Noise_NK: handshakePattern{
+	NoiseNK: handshakePattern{
 		name: "NK",
 		preMessagePatterns: []messagePattern{
 			messagePattern{},        // →
@@ -166,7 +176,7 @@ var patterns = map[noiseHandshakeType]handshakePattern{
 		},
 	},
 
-	Noise_XX: handshakePattern{
+	NoiseXX: handshakePattern{
 		name: "XX",
 		preMessagePatterns: []messagePattern{
 			messagePattern{}, // →
@@ -186,14 +196,14 @@ var patterns = map[noiseHandshakeType]handshakePattern{
 		      -> e
 		      <- e, ee, se, s, es
 	*/
-	Noise_KX: handshakePattern{
+	NoiseKX: handshakePattern{
 		name: "KX",
 		preMessagePatterns: []messagePattern{
 			messagePattern{token_s}, // →
 			messagePattern{},        // ←
 		},
 		messagePatterns: []messagePattern{
-			messagePattern{token_e},                                        // →
+			messagePattern{token_e}, // →
 			messagePattern{token_e, token_ee, token_se, token_s, token_es}, // ←
 		},
 	},
@@ -205,7 +215,7 @@ var patterns = map[noiseHandshakeType]handshakePattern{
 		  <- e, ee
 		  -> s, se
 	*/
-	Noise_XK: handshakePattern{
+	NoiseXK: handshakePattern{
 		name: "XK",
 		preMessagePatterns: []messagePattern{
 			messagePattern{},        // →
@@ -224,7 +234,7 @@ var patterns = map[noiseHandshakeType]handshakePattern{
 		-> e, es, s, ss
 		<- e, ee, se
 	*/
-	Noise_IK: handshakePattern{
+	NoiseIK: handshakePattern{
 		name: "IK",
 		preMessagePatterns: []messagePattern{
 			messagePattern{},        // →
@@ -240,7 +250,7 @@ var patterns = map[noiseHandshakeType]handshakePattern{
 		 -> e, s
 		 <- e, ee, se, s, es
 	*/
-	Noise_IX: handshakePattern{
+	NoiseIX: handshakePattern{
 		name: "IX",
 		preMessagePatterns: []messagePattern{
 			messagePattern{}, // →
@@ -257,7 +267,7 @@ var patterns = map[noiseHandshakeType]handshakePattern{
 		  -> e
 		  <- e, ee, psk
 	*/
-	Noise_NNpsk2: handshakePattern{
+	NoiseNNpsk2: handshakePattern{
 		name: "NNpsk2",
 		preMessagePatterns: []messagePattern{
 			messagePattern{}, // →

--- a/libdisco/patterns_test.go
+++ b/libdisco/patterns_test.go
@@ -26,11 +26,11 @@ func TestNoiseKK(t *testing.T) {
 	// init
 	clientConfig := Config{
 		KeyPair:          GenerateKeypair(nil),
-		HandshakePattern: Noise_KK,
+		HandshakePattern: NoiseKK,
 	}
 	serverConfig := Config{
 		KeyPair:          GenerateKeypair(nil),
-		HandshakePattern: Noise_KK,
+		HandshakePattern: NoiseKK,
 	}
 
 	// set up remote keys
@@ -86,16 +86,16 @@ func TestNoiseKK(t *testing.T) {
 
 func TestNoiseNK(t *testing.T) {
 
-	test_pattern := Noise_NK
+	testPattern := NoiseNK
 
 	// init
 	clientConfig := Config{
 		KeyPair:          GenerateKeypair(nil),
-		HandshakePattern: test_pattern,
+		HandshakePattern: testPattern,
 	}
 	serverConfig := Config{
 		KeyPair:          GenerateKeypair(nil),
-		HandshakePattern: test_pattern,
+		HandshakePattern: testPattern,
 	}
 
 	// setup remote key
@@ -154,14 +154,14 @@ func TestNoiseXX(t *testing.T) {
 	clientKeyPair := GenerateKeypair(nil)
 	clientConfig := Config{
 		KeyPair:              clientKeyPair,
-		HandshakePattern:     Noise_XX,
+		HandshakePattern:     NoiseXX,
 		PublicKeyVerifier:    publicKeyVerifier,
 		StaticPublicKeyProof: CreateStaticPublicKeyProof(rootKey.privateKey, clientKeyPair.PublicKey[:]),
 	}
 	serverKeyPair := GenerateKeypair(nil)
 	serverConfig := Config{
 		KeyPair:              serverKeyPair,
-		HandshakePattern:     Noise_XX,
+		HandshakePattern:     NoiseXX,
 		PublicKeyVerifier:    publicKeyVerifier,
 		StaticPublicKeyProof: CreateStaticPublicKeyProof(rootKey.privateKey, serverKeyPair.PublicKey[:]),
 	}
@@ -218,12 +218,12 @@ func TestNoiseN(t *testing.T) {
 	// init
 	serverConfig := Config{
 		KeyPair:          GenerateKeypair(nil),
-		HandshakePattern: Noise_N,
+		HandshakePattern: NoiseN,
 	}
 
 	clientConfig := Config{
 		KeyPair:          GenerateKeypair(nil),
-		HandshakePattern: Noise_N,
+		HandshakePattern: NoiseN,
 		RemoteKey:        serverConfig.KeyPair.PublicKey[:],
 	}
 

--- a/libdisco/symmetric.go
+++ b/libdisco/symmetric.go
@@ -23,6 +23,7 @@ func Hash(input []byte, outputLength int) []byte {
 	return hash.PRF(outputLength)
 }
 
+// DiscoHash represents a strobe hash
 type DiscoHash struct {
 	strobeState  strobe.Strobe
 	streaming    bool
@@ -56,7 +57,7 @@ func (d *DiscoHash) WriteTuple(inputData []byte) (written int, err error) {
 	return
 }
 
-// Read reads more output from the hash; reading affects the hash's
+// Sum reads more output from the hash; reading affects the hash's
 // state. (DiscoHash.Read is thus very different from Hash.Sum)
 // It never returns an error.
 func (d *DiscoHash) Sum() []byte {
@@ -112,10 +113,9 @@ func VerifyIntegrity(key, plaintextAndTag []byte) ([]byte, error) {
 	// verify tag
 	if !hash.Recv_MAC(false, tag) {
 		return nil, errors.New("disco: the plaintext has been modified")
-	} else {
-		return plaintext, nil
 	}
 
+	return plaintext, nil
 }
 
 // Encrypt allows you to encrypt a plaintext message with a key of any size greater than 128 bits (16 bytes).
@@ -165,7 +165,7 @@ func Decrypt(key, ciphertext []byte) ([]byte, error) {
 	return plaintext, nil
 }
 
-// Encrypt allows you to encrypt a plaintext message with a key of any size greater than 128 bits (16 bytes).
+// EncryptAndAuthenticate allows you to encrypt a plaintext message with a key of any size greater than 128 bits (16 bytes).
 func EncryptAndAuthenticate(key, plaintext, ad []byte) []byte {
 	if len(key) < 16 {
 		panic("disco: using a key smaller than 128-bit (16 bytes) has security consequences")
@@ -190,7 +190,7 @@ func EncryptAndAuthenticate(key, plaintext, ad []byte) []byte {
 	return ciphertext
 }
 
-// Decrypt allows you to decrypt a message that was encrypted with the Encrypt function.
+// DecryptAndAuthenticate allows you to decrypt a message that was encrypted with the Encrypt function.
 func DecryptAndAuthenticate(key, ciphertext, ad []byte) ([]byte, error) {
 	if len(key) < 16 {
 		return nil, errors.New("disco: using a key smaller than 128-bit (16 bytes) has security consequences")

--- a/libdisco/symmetric_test.go
+++ b/libdisco/symmetric_test.go
@@ -30,7 +30,7 @@ func TestSum(t *testing.T) {
 	h2.Write([]byte(fullmessage))
 	out2 := h2.Sum()
 
-	for idx, _ := range out1 {
+	for idx := range out1 {
 		if out1[idx] != out2[idx] {
 			t.Fatal("Sum function does not work")
 		}
@@ -39,7 +39,7 @@ func TestSum(t *testing.T) {
 	// trying with Hash()
 	out3 := Hash([]byte(fullmessage), 32)
 
-	for idx, _ := range out1 {
+	for idx := range out1 {
 		if out1[idx] != out3[idx] {
 			t.Fatal("Sum function does not work")
 		}
@@ -51,7 +51,7 @@ func TestSum(t *testing.T) {
 	h2.Write([]byte(message3))
 	out2 = h2.Sum()
 
-	for idx, _ := range out1 {
+	for idx := range out1 {
 		if out1[idx] != out2[idx] {
 			t.Fatal("Sum function does not work")
 		}
@@ -60,7 +60,7 @@ func TestSum(t *testing.T) {
 	// tring with Hash()
 	out3 = Hash([]byte(fullmessage+message3), 32)
 
-	for idx, _ := range out1 {
+	for idx := range out1 {
 		if out1[idx] != out3[idx] {
 			t.Fatal("Sum function does not work")
 		}
@@ -85,7 +85,7 @@ func TestHashOutputHashOutput(t *testing.T) {
 	h2.Write([]byte(message3))
 	out2 := h2.Sum()
 
-	for idx, _ := range out1 {
+	for idx := range out1 {
 		if out1[idx] != out2[idx] {
 			t.Fatal("Sum function affects the hash state")
 		}
@@ -112,7 +112,7 @@ func TestTupleHash(t *testing.T) {
 	out2 := h2.Sum()
 
 	same := true
-	for idx, _ := range out1 {
+	for idx := range out1 {
 		if out1[idx] != out2[idx] {
 			same = false
 			break
@@ -136,7 +136,7 @@ func TestTupleHash(t *testing.T) {
 	h4.WriteTuple([]byte(message4))
 	out4 := h4.Sum()
 
-	for idx, _ := range out3 {
+	for idx := range out3 {
 		if out3[idx] != out4[idx] {
 			t.Fatal("Tuple hashing doesn't work properly with streaming")
 		}
@@ -164,14 +164,14 @@ func TestProtectVerifyIntegrity(t *testing.T) {
 	if err != nil {
 		t.Fatal("Protect/Verify did not work")
 	}
-	for idx, _ := range message {
+	for idx := range message {
 		if message[idx] != retrievedMessage[idx] {
 			t.Fatal("Verify did not work")
 		}
 	}
 
 	// tamper
-	plaintextAndTag[len(plaintextAndTag)-1] += 1
+	plaintextAndTag[len(plaintextAndTag)-1]++
 
 	_, err = VerifyIntegrity(key, plaintextAndTag)
 	if err == nil {
@@ -213,7 +213,7 @@ func TestEncryptDecrypt(t *testing.T) {
 		if len(plaintext) != len(decrypted) {
 			t.Fatal("Decrypt did not work")
 		}
-		for idx, _ := range plaintext {
+		for idx := range plaintext {
 			if plaintext[idx] != decrypted[idx] {
 				t.Fatal("Decrypt did not work")
 			}
@@ -257,7 +257,7 @@ func TestEncryptDecryptAndAuthenticate(t *testing.T) {
 		if len(plaintext) != len(decrypted) {
 			t.Fatal("Decrypt did not work")
 		}
-		for idx, _ := range plaintext {
+		for idx := range plaintext {
 			if plaintext[idx] != decrypted[idx] {
 				t.Fatal("Decrypt did not work")
 			}

--- a/web/discocrypto.com/src/components/Keys.vue
+++ b/web/discocrypto.com/src/components/Keys.vue
@@ -69,7 +69,7 @@ proof := libdisco.CreateStaticPublicKeyProof(rootPrivateKey, serverKeyPair.Publi
 		<p>3. configure the server to send its static public key along with its proof:</p>
 
 		<pre><code>serverConfig := libdisco.Config{
-  HandshakePattern:     libdisco.Noise_NX,
+  HandshakePattern:     libdisco.NoiseNX,
   KeyPair:              serverKeyPair,
   StaticPublicKeyProof: proof,
 }</code></pre>
@@ -87,7 +87,7 @@ someCallbackFunction := CreatePublicKeyVerifier(rootPublicKey)
 
 // we configure the client
 clientConfig := libdisco.Config{
-  HandshakePattern:  libdisco.Noise_NK,
+  HandshakePattern:  libdisco.NoiseNK,
   PublicKeyVerifier: someCallbackFunction,
 }
 </code></pre>

--- a/web/discocrypto.com/src/components/LandingPage.vue
+++ b/web/discocrypto.com/src/components/LandingPage.vue
@@ -40,7 +40,7 @@
     <p>To set it up, follow <a href="https://golang.org/pkg/net/" target="_blank">Golang's net/conn</a> standard way of setting up a server with a libdisco config:</p>
 
     <pre><code>serverConfig := libdisco.Config{
-  HandshakePattern: libdisco.Noise_NK,
+  HandshakePattern: libdisco.NoiseNK,
   KeyPair:          serverKeyPair,
 }
 listener, err := libdisco.Listen("tcp", "127.0.0.1:6666", &serverConfig)
@@ -49,7 +49,7 @@ server, err := listener.Accept()</code></pre>
     <p>and the standard way of setting up a client with a libdisco config:</p>
 
     <pre><code>clientConfig := libdisco.Config{
-  HandshakePattern: libdisco.Noise_NK,
+  HandshakePattern: libdisco.NoiseNK,
   RemoteKey:        serverKey,
 }
 client, err := libdisco.Dial("tcp", "127.0.0.1:6666", &clientConfig)

--- a/web/discocrypto.com/src/components/handshakes/Noise_K.vue
+++ b/web/discocrypto.com/src/components/handshakes/Noise_K.vue
@@ -8,7 +8,7 @@
 
 		<img src="./assets/Noise_K.png" alt="Noise_K handshake">
 
-		<h2><i class="fa fa-caret-right" aria-hidden="true"></i> Use cases</h2> 
+		<h2><i class="fa fa-caret-right" aria-hidden="true"></i> Use cases</h2>
 
 		<p>Like any one-way pattern. If the server never needs to (or cannot) reply to the client, Noise_K might be a good fit. In addition, this handshake authenticates both side of the connection via <strong>public-key pinning</strong>. This means that both sides need to know in advance each other's static public key.</p>
 
@@ -30,7 +30,7 @@ fmt.Println("server's public key:", serverKeyPair.ExportPublicKey())
 
 // configuring the Disco connection
 serverConfig := libdisco.Config{
-	HandshakePattern: libdisco.Noise_K,
+	HandshakePattern: libdisco.NoiseK,
 	KeyPair:          serverKeyPair,
 }
 
@@ -57,7 +57,7 @@ fmt.Println("client's public key:", clientKeyPair.ExportPublicKey())
 
 // configure the Disco connection
 clientConfig := libdisco.Config{
-	HandshakePattern: libdisco.Noise_K,
+	HandshakePattern: libdisco.NoiseK,
 	KeyPair:          clientKeyPair,
 }
 

--- a/web/discocrypto.com/src/components/handshakes/Noise_KK.vue
+++ b/web/discocrypto.com/src/components/handshakes/Noise_KK.vue
@@ -8,7 +8,7 @@
 
 		<img src="./assets/Noise_KK.png" alt="Noise_KK handshake">
 
-		<h2><i class="fa fa-caret-right" aria-hidden="true"></i> Use cases</h2> 
+		<h2><i class="fa fa-caret-right" aria-hidden="true"></i> Use cases</h2>
 
 		<p>If your protocol involves several peers and both sides of a connection have a way to know the other side's public static key prior to starting the handshake, Noise_KK is a good fit.</p>
 
@@ -25,7 +25,7 @@
 		<h3>server:</h3>
 
 		<pre><code>serverConfig := libdisco.Config{
-	HandshakePattern: libdisco.Noise_KK,
+	HandshakePattern: libdisco.NoiseKK,
 	KeyPair:          serverKeyPair,
 	// the public static key of the client
 	RemoteKey: clientPublicKey
@@ -43,7 +43,7 @@ fmt.Println("listening on:", addr)</code></pre>
 		<h3>client:</h3>
 
 		<pre><code>clientConfig := libdisco.Config{
-	HandshakePattern: libdisco.Noise_KK,
+	HandshakePattern: libdisco.NoiseKK,
 	KeyPair:          clientKeyPair,
 	// the public static key of the server
 	RemoteKey: serverPublicKey

--- a/web/discocrypto.com/src/components/handshakes/Noise_N.vue
+++ b/web/discocrypto.com/src/components/handshakes/Noise_N.vue
@@ -8,12 +8,12 @@
 
 		<img src="./assets/Noise_N.png" alt="Noise_N handshake">
 
-		<h2><i class="fa fa-caret-right" aria-hidden="true"></i> Use cases</h2> 
+		<h2><i class="fa fa-caret-right" aria-hidden="true"></i> Use cases</h2>
 
 		<p>This handshake pattern is useful for clients that always talk to a single server. In addition, since it is a one-way pattern, the server never talks back to them. The server also doesn't require the client to authenticate itself.</p>
 
 		<p>If client authentication is needed, refer to <router-link to="/protocol/Noise_K">Noise_K</router-link> or <router-link to="/protocol/Noise_X">Noise_X</router-link>.</p>
-	
+
 		<h2><i class="fa fa-caret-right" aria-hidden="true"></i> Example of configuration</h2>
 
 		<p>The client needs to have prior knowledge to the server's public static key. In this example we just pass it as an <code>stdin</code> argument to the client's CLI, but in practice it should be hardcoded.</p>
@@ -30,7 +30,7 @@ serverKeyPair := libdisco.GenerateKeypair(nil)
 // configuring the Disco connection with a Noise_N handshake
 // in which the client already knows the server's static public key
 serverConfig := libdisco.Config{
-	HandshakePattern: libdisco.Noise_N,
+	HandshakePattern: libdisco.NoiseN,
 	KeyPair:          serverKeyPair,
 }
 // listen on port 6666
@@ -53,7 +53,7 @@ serverKey, _ := hex.DecodeString(serverPubKey)
 // configure the Disco connection with Noise_N
 // meaning the client knows the server's static public key (retrieved from the CLI)
 clientConfig := libdisco.Config{
-	HandshakePattern: libdisco.Noise_N,
+	HandshakePattern: libdisco.NoiseN,
 	RemoteKey:        serverKey,
 }
 // Dial the port 6666 of localhost

--- a/web/discocrypto.com/src/components/handshakes/Noise_NK.vue
+++ b/web/discocrypto.com/src/components/handshakes/Noise_NK.vue
@@ -8,7 +8,7 @@
 
 		<img src="./assets/Noise_NK.png" alt="Noise_NK handshake">
 
-		<h2><i class="fa fa-caret-right" aria-hidden="true"></i> Use cases</h2> 
+		<h2><i class="fa fa-caret-right" aria-hidden="true"></i> Use cases</h2>
 
 		<p>Noise_NK is a relevant handshake pattern if your clients already know a server's static public key. This pattern does not authenticate the client nor does it rely on an external root signing key.</p>
 
@@ -26,7 +26,7 @@
 		<h3>server:</h3>
 
 		<pre><code>serverConfig := libdisco.Config{
-	HandshakePattern: libdisco.Noise_NK,
+	HandshakePattern: libdisco.NoiseNK,
 	KeyPair:          serverKeyPair,
 }
 // listen on port 6666
@@ -41,7 +41,7 @@ fmt.Println("listening on:", addr)</code></pre>
 		<h3>client:</h3>
 
 		<pre><code>clientConfig := libdisco.Config{
-	HandshakePattern: libdisco.Noise_NK,
+	HandshakePattern: libdisco.NoiseNK,
 	// the server's static public key.
 	RemoteKey:        serverPublicKey,
 }

--- a/web/discocrypto.com/src/components/handshakes/Noise_NNpsk2.vue
+++ b/web/discocrypto.com/src/components/handshakes/Noise_NNpsk2.vue
@@ -8,7 +8,7 @@
 
 		<img src="./assets/Noise_NNpsk2.png" alt="Noise_NNpsk2 handshake">
 
-		<h2><i class="fa fa-caret-right" aria-hidden="true"></i> Use cases</h2> 
+		<h2><i class="fa fa-caret-right" aria-hidden="true"></i> Use cases</h2>
 
 		<p>If you are only dealing with one client and one server, and can manually hardcode a common 32-byte random value on each peer, you probably do not need to deal with public keys and should use this handshake pattern.</p>
 
@@ -17,7 +17,7 @@
 		    <p>Security Consideration</p>
 		  </div>
 		  <div class="message-body">
-		    The same amount of care as with private keys should be taken to store and protect shared secrets. 
+		    The same amount of care as with private keys should be taken to store and protect shared secrets.
 		  </div>
 		</article>
 
@@ -31,9 +31,9 @@
 
 		<pre><code>// configuring the Disco connection
 serverConfig := libdisco.Config{
-	HandshakePattern: libdisco.Noise_NNpsk2,
+	HandshakePattern: libdisco.NoiseNNpsk2,
 	// your 32-byte shared secret
-	PreSharedKey: sharedSecret, 
+	PreSharedKey: sharedSecret,
 }
 
 // listen on port 6666
@@ -49,9 +49,9 @@ fmt.Println("listening on:", addr)</code></pre>
 
 		<pre><code>// configure the Disco connection
 clientConfig := libdisco.Config{
-	HandshakePattern: libdisco.Noise_NNpsk2,
+	HandshakePattern: libdisco.NoiseNNpsk2,
 	// your 32-byte shared secret
-	PreSharedKey: sharedSecret, 
+	PreSharedKey: sharedSecret,
 }
 
 // Dial the port 6666 of localhost

--- a/web/discocrypto.com/src/components/handshakes/Noise_NX.vue
+++ b/web/discocrypto.com/src/components/handshakes/Noise_NX.vue
@@ -88,7 +88,7 @@ proof := CreateStaticPublicKeyProof(rootPrivateKey, peerPublicKey)
 		<p>Once the proof has been computed, it can be passed to the server which will be able to configure itself for a Noise_NX setup:</p>
 
 		<pre><code>serverConfig := libdisco.Config{
-  HandshakePattern:     libdisco.Noise_NX,
+  HandshakePattern:     libdisco.NoiseNX,
   KeyPair:              serverKeyPair,
   StaticPublicKeyProof: proof,
 }
@@ -106,7 +106,7 @@ fmt.Println("listening on:", addr)</code></pre>
 		<p>the client needs to be configured with a function capable of acting on the static public key the server will send (as part of the handshake). Without this, there are no guarantees that the static public key the server sends is "legit".</p>
 
 		<pre><code>clientConfig := libdisco.Config{
-  HandshakePattern:  libdisco.Noise_NX,
+  HandshakePattern:  libdisco.NoiseNX,
   PublicKeyVerifier: verifier,
 }</code></pre>
 
@@ -123,7 +123,7 @@ verifier := libdisco.CreatePublicKeyVerifier(rootPublicKey)
 
 // configure the Disco connection
 clientConfig := libdisco.Config{
-	HandshakePattern:  libdisco.Noise_NX,
+	HandshakePattern:  libdisco.NoiseNX,
 	PublicKeyVerifier: verifier,
 }
 

--- a/web/discocrypto.com/src/components/handshakes/Noise_X.vue
+++ b/web/discocrypto.com/src/components/handshakes/Noise_X.vue
@@ -86,7 +86,7 @@ verifier := libdisco.CreatePublicKeyVerifier(rootPublicKey)
 // configuring the Disco connection
 // in which the client already knows the server's public key
 serverConfig := libdisco.Config{
-	HandshakePattern:  libdisco.Noise_X,
+	HandshakePattern:  libdisco.NoiseX,
 	KeyPair:           serverKeyPair,
 	PublicKeyVerifier: verifier,
 }
@@ -127,7 +127,7 @@ if err != nil || len(proof) != 64 {
 clientConfig := libdisco.Config{
 	KeyPair:              clientKeyPair,
 	RemoteKey:            serverPublicKey,
-	HandshakePattern:     libdisco.Noise_X,
+	HandshakePattern:     libdisco.NoiseX,
 	StaticPublicKeyProof: proof,
 }
 

--- a/web/discocrypto.com/src/components/handshakes/Noise_XX.vue
+++ b/web/discocrypto.com/src/components/handshakes/Noise_XX.vue
@@ -81,7 +81,7 @@ verifier := libdisco.CreatePublicKeyVerifier(rootPublicKey)
 
 // configure the Disco connection with Noise_XX
 serverConfig := libdisco.Config{
-	HandshakePattern:     libdisco.Noise_XX,
+	HandshakePattern:     libdisco.NoiseXX,
 	KeyPair:              serverKeyPair,
 	PublicKeyVerifier:    verifier,
 	StaticPublicKeyProof: proof,
@@ -111,7 +111,7 @@ verifier := libdisco.CreatePublicKeyVerifier(rootPublicKey)
 // configure the Disco connection with Noise_XX
 clientConfig := libdisco.Config{
 	KeyPair:              clientKeyPair,
-	HandshakePattern:     libdisco.Noise_XX,
+	HandshakePattern:     libdisco.NoiseXX,
 	PublicKeyVerifier:    verifier,
 	StaticPublicKeyProof: proof,
 }

--- a/web/discocrypto.com/src/components/handshakes/Overview.vue
+++ b/web/discocrypto.com/src/components/handshakes/Overview.vue
@@ -98,7 +98,7 @@ func main() {
 	serverKeyPair := libdisco.GenerateKeypair(nil)
 
 	serverConfig := libdisco.Config{
-		HandshakePattern: libdisco.Noise_NK,
+		HandshakePattern: libdisco.NoiseNK,
 		KeyPair:          serverKeyPair,
 	}
 
@@ -132,7 +132,7 @@ func main() {
 	<h3><i class="fa fa-caret-right" aria-hidden="true"></i> Client</h3>
 
 	<p>The client can simply use the <code>Dial()</code> paradigm using the public key of the server:</p>
-	
+
 	<pre><code>package main
 
 import (
@@ -146,7 +146,7 @@ func main() {
 	// replace this with the server's public key!
 	serverKey, _ := hex.DecodeString("e424214ab16f56def7778e9a3d36d891221c4f5b38c8b2679ccbdaed5c27e735")
 	clientConfig := libdisco.Config{
-		HandshakePattern: libdisco.Noise_NK,
+		HandshakePattern: libdisco.NoiseNK,
 		RemoteKey:        serverKey,
 	}
 


### PR DESCRIPTION
I implemented the schnorrkel algorithm which in my opinion is better suited for curve25519, I also used the ristretto255 library instead of the previous one. Fixed various golang idiomatic errors and linting issues.
All tests are passing.